### PR TITLE
Updates for Blender 2.8

### DIFF
--- a/mesh_triangle/__init__.py
+++ b/mesh_triangle/__init__.py
@@ -35,11 +35,13 @@ DEALINGS IN THE SOFTWARE.
 
 """
 
+# https://b3d.interplanety.org/en/porting-add-on-from-blender-2-7-to-blender-2-8/
+
 bl_info = {
     "name": "Triangle",
     "author": "Tom Svilans (Blender wrapper)",
     "version": (1, 0, 0),
-    "blender": (2, 79, 0),
+    "blender": (2, 80, 0),
     "location": "View3D > Toolbar",
     "warning": "",
     "description": "A two-dimensional quality mesh generator and Delaunay triangulator.",
@@ -69,12 +71,15 @@ def get_nonmanifold_edges(mymesh):
     return culprits
 
 def triangulate_object(obj_in, args):
-    mesh_in = obj_in.to_mesh(bpy.context.scene, True, 'RENDER')
+    mesh_in = obj_in.to_mesh() # XXX Don't have depsgraph for True, depsgraph)
+    
     verts = [x.co for x in mesh_in.vertices]
     Nv = len(verts)
     faces = [[y for y in x.vertices] for x in mesh_in.polygons]
     border = get_nonmanifold_edges(mesh_in)
 
+    obj_in.to_mesh_clear()
+    
     #if ('v' in args or 'D' in args):
     #    return triangulate(verts, faces, border, args, True)[1]
     res = triangulate(verts, faces, border, args)
@@ -104,56 +109,56 @@ class Triangulate(bpy.types.Operator):
     bl_label = "Triangulate (Triangle)"
     bl_options = {'REGISTER', 'UNDO'}
 
-    args = StringProperty(
+    args : StringProperty(
             name="Args",
             description="Input arguments for Triangle",
             default="pq20a1ziV",
             )
 
-    use_args = BoolProperty(
+    use_args : BoolProperty(
             name="Use args",
             description="Use command line arg string instead of checkboxes",
             default=False)
 
-    cl_p = BoolProperty(
+    cl_p : BoolProperty(
             name="PSLG",
             description="Triangulates a Planar Straight Line Graph (.poly file)",
             default=True)
-    cl_r = BoolProperty(
+    cl_r : BoolProperty(
             name="Refine",
             description="Refines a previously generated mesh",
             default=False)
-    cl_q = BoolProperty(
+    cl_q : BoolProperty(
             name="Quality",
             description="Quality mesh generation with no angles smaller than the specified angle",
             default=True)
-    cl_q_angle = FloatProperty(
+    cl_q_angle : FloatProperty(
             name="Quality angle",
             description="Angle limit for quality mesh generation",
             default=20.0,
             max=35.0,
             min=0.0)
-    cl_a = BoolProperty(
+    cl_a : BoolProperty(
             name="Area",
             description="Imposes a maximum triangle area constraint",
             default = False)
-    cl_a_value = FloatProperty(
+    cl_a_value : FloatProperty(
             name="Area value",
             description="Value for area constraint",
             default=1.0,
             min=0.001)
-    cl_c = BoolProperty(
+    cl_c : BoolProperty(
             name="Convex hull",
             description="Encloses the convex hull with segments",
             default=False)
-    cl_D = BoolProperty(
+    cl_D : BoolProperty(
             name="Delaunay",
             description="Conforming Delaunay: use this switch if you want " \
             "all triangles in the mesh to be Delaunay, and not just constrained " \
             "Delaunay; or if you want to ensure that all Voronoi vertices lie within " \
             "the triangulation",
             default=False)
-    cl_v = BoolProperty(
+    cl_v : BoolProperty(
             name="Voronoi",
             description="Outputs the Voronoi diagram associated with the triangulation. "\
             "Does not attempt to detect degeneracies, so some Voronoi vertices may be duplicated",
@@ -238,14 +243,15 @@ class Triangulate(bpy.types.Operator):
                 v.select = True
 
             obj.matrix_world = o.matrix_world
-            ctx.scene.objects.link(obj)
+            
+            ctx.scene.collection.children[0].objects.link(obj)
 
         return {'FINISHED'}
 
-class TrianglePanel(bpy.types.Panel):
+class TRIANGLE_PT_panel(bpy.types.Panel):
     """Creates a Panel in the Object properties window"""
     bl_space_type = 'VIEW_3D'
-    bl_region_type = 'TOOLS'
+    bl_region_type = 'UI'
     bl_category = 'Tools'
     bl_context = "objectmode"
     bl_label = "Triangle"
@@ -262,10 +268,10 @@ def menu_func(self, context):
 
 def register():
     bpy.utils.register_class(Triangulate)
-    bpy.utils.register_class(TrianglePanel)
+    bpy.utils.register_class(TRIANGLE_PT_panel)
 
 def unregister():
-    bpy.utils.unregister_class(TrianglePanel)
+    bpy.utils.unregister_class(TRIANGLE_PT_panel)
     bpy.utils.unregister_class(Triangulate)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi, I made some tweaks to get your addon to work with Blender 2.8. Not everything is fully working yet:

- Calling the addon can only be done through the F3 menu, there's no button for it yet
- After applying the triangulation the duplicated and triangulated mesh isn't immediately visible it seems. Needs a select and edit-mode toggle.

I also wonder about the binary yriangle shared libs you include. Was there a custom build instruction involved that isn't mentioned? As the referenced https://github.com/libigl/triangle can only produce a static library with the cmake build file.